### PR TITLE
Support setting button colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,12 @@
 # React Native Radio button for Android
 
-Native Android radio-button component
-
+Native Android radio-button component, originally forked from https://github.com/sichacvah/react-native-radio-button-android
 
 ## Installation
 
 ```
-npm i react-native-radio-button-android --save
-```
-
-1. ```android/settings.gradle```:: Add the following snippet
-```gradle
-include ':react-native-radio-button-android'
-project(':react-native-radio-button-android').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-radio-button-android/android')
-```
-
-2. ```android/app/build.gradle```: Add in dependencies block.
-```gradle
-dependences {
-  ...
-  compile project(':react-native-radio-button-android')
-}
-```
-3. ```android/app/src/main/java/com/<your_app>/MainActivity.java```: Import package and add to react list of packages.
-```java
-import io.sichacvah.react.radio_button.RadioButtonPackage;
-...
-
-protected List<ReactPackage> getPackages() {
-  return Arrays.<ReactPackage>asList(
-    ...
-    new RadioButtonPackage()
-  );
-}
+yarn add @rh389/react-native-radio-button
+react-native link @rh389/react-native-radio-button
 ```
 
 ### License: ISC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 dependencies {
   compile fileTree(include: ['*.jar'], dir: 'libs')
   compile 'com.facebook.react:react-native:+'
-  compile 'com.android.support:appcompat-v7:23.0.1'
+  compile 'com.android.support:appcompat-v7:23.4.0'
   compile 'com.android.support:support-annotations:+'
   //compile files('libs/js.jar')
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.sichacvah.react.notification">
+          package="io.sichacvah.react.radio_button">
 </manifest>

--- a/android/src/main/java/io/sichacvah/react/radio_button/RadioButtonManager.java
+++ b/android/src/main/java/io/sichacvah/react/radio_button/RadioButtonManager.java
@@ -3,6 +3,9 @@ package io.sichacvah.react.radio_button;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+
+import android.content.res.ColorStateList;
+import android.support.v4.widget.CompoundButtonCompat;
 import android.widget.CompoundButton;
 import android.content.ContextWrapper;
 
@@ -18,7 +21,7 @@ public class RadioButtonManager extends SimpleViewManager<RadioButtonView> {
 
   private static final CompoundButton.OnCheckedChangeListener ON_CHECKED_CHANGE_LISTENER =
     new CompoundButton.OnCheckedChangeListener() {
-      @Override 
+      @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         ReactContext reactContext = (ReactContext) ((ContextWrapper) buttonView.getContext()).getBaseContext();
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
@@ -59,4 +62,8 @@ public class RadioButtonManager extends SimpleViewManager<RadioButtonView> {
     checkbox.setEnabled(!disabled);
   }
 
+  @ReactProp(name = "color", customType = "Color")
+  public void setColor(RadioButtonView checkbox, Integer color) {
+    CompoundButtonCompat.setButtonTintList(checkbox, ColorStateList.valueOf(color));
+  }
 }

--- a/index.android.js
+++ b/index.android.js
@@ -23,6 +23,7 @@ class RadioButton extends React.Component {
         ref={'RCTRadioButton'}
         style={[this.props.style, styles.radioButton]}
         on={this.props.value}
+        color={this.props.color}
         disabled={this.props.disabled}
         onChange={this._onChange}
         />
@@ -47,6 +48,7 @@ RadioButton.propTypes = {
   value: PropTypes.bool,
   text: PropTypes.string,
   onValueChange: PropTypes.func,
+  color: PropTypes.string,
   disabled: PropTypes.bool,
   ...ViewPropTypes
 };

--- a/package.json
+++ b/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "react-native-radio-button-android",
-  "version": "1.0.4",
-  "description": "Android native, and pure js for IOS",
+  "name": "@rh389/react-native-radio-button",
+  "version": "1.1.0",
+  "description": "A controlled radio button for React Native which uses a native component on android",
   "nativePackage": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/sichacvah/react-native-radio-button-android.git"
+    "url": "git+ssh://git@github.com/rh389/react-native-radio-button.git"
   },
   "keywords": [
-    "React",
-    "Native",
-    "JAVA",
-    "Javascript"
+    "react-native",
+    "android",
+    "ios",
+    "radio"
   ],
-  "author": "sichacvah",
+  "author": "sichacvah and rh389",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/sichacvah/react-native-radio-button-android/issues"
+    "url": "https://github.com/rh389/react-native-radio-button/issues"
   },
-  "homepage": "https://github.com/sichacvah/react-native-radio-button-android#readme",
+  "homepage": "https://github.com/rh389/react-native-radio-button#readme",
   "devDependencies": {
     "react": "^15.3.0",
     "react-native": "^0.30.0"


### PR DESCRIPTION
Support setting a fixed colour using a `color` prop.

Includes a requirement bump for appcompat because I was seeing [this bug](https://issuetracker.google.com/issues/37029454) while using `23.0.1`, but it's fine in `23.4.0`.