### PR TITLE
Fix package name in AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.sichacvah.react.notification">
+          package="io.sichacvah.react.radio_button">
 </manifest>


### PR DESCRIPTION
I guess this is just an oversight copied across from some other package? Changed to match the java package name.